### PR TITLE
Fixed promise which detects preproc header so it closes every open resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "rech-editor-internal",
     "displayName": "Rech Internal",
     "description": "Package for using Rech's extensions with Visual Studio Code in Rech's intranet",
-    "version": "0.0.54",
+    "version": "0.0.55",
     "publisher": "rechinformatica",
     "engines": {
         "vscode": "^1.35.0"

--- a/src/preproc/PreprocHeaderDetector.ts
+++ b/src/preproc/PreprocHeaderDetector.ts
@@ -28,7 +28,8 @@ export class PreprocHeaderDetector {
             }
 
             // Creates instance to read file lines
-            const rl = readline.createInterface({ input: fs.createReadStream(file) });
+            const readStream = fs.createReadStream(file);
+            const rl = readline.createInterface({ input: readStream });
 
             // Variables to control whether preprocessor header has been found
             let streamClosed = false;
@@ -53,10 +54,15 @@ export class PreprocHeaderDetector {
                     lineNumber++;
                 }
             };
+
+            const closeCallbackFn = function (): void {
+                readStream.close();
+                resolve(preprocessedSource);
+            }
             
             // Configure callbacks
             rl.on('line', (line) => readCallbackFn(line));
-            rl.on('close', () => resolve(preprocessedSource));
+            rl.on('close', () => closeCallbackFn());
         });
     }
 


### PR DESCRIPTION
There was a problem on PreprocHeaderDetector class which was leaving some resources open.
It caused some files not to be deleted by other applications.